### PR TITLE
Fix month spelling and align weekday order; simplify first-day index calculation

### DIFF
--- a/Monthly Calender/index.js
+++ b/Monthly Calender/index.js
@@ -1,8 +1,8 @@
 const month = document.querySelector(".inner-month");
 const fulldate = document.querySelector(".inner-data");
 const datesDiv = document.querySelector(".dates");
-const months = ["January","February","March","April","May","June","July","Auguest","September","October","November","December"];
-const days = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"];
+const months = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+const days = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
 const dateSys = new Date;
 month.innerText = months[dateSys.getMonth()];
 fulldate.innerText = dateSys.toString().slice(0,15);
@@ -38,12 +38,7 @@ function indexBlock(index,element){
 };
 let index;
 function updateIndex(){
-    var firstDay = new Date(dateSys.getFullYear(), dateSys.getMonth(), 1).toString().slice(0,3);
-    days.forEach((day)=>{
-        if(day == firstDay){
-            index=days.indexOf(day);
-        };
-    });
+    index = new Date(dateSys.getFullYear(), dateSys.getMonth(), 1).getDay();
 };
 function execute(){
     updateIndex();


### PR DESCRIPTION
### Motivation
- Fix calendar rendering by correcting a misspelled month and aligning the weekday array with JavaScript `Date.getDay()` semantics so the first-day index is computed correctly.

### Description
- Corrected the `months` array (fixed `Auguest` -> `August`), reordered the `days` array to start with `Sun`, and simplified `updateIndex()` to set `index` via `new Date(...).getDay()` instead of string matching.

### Testing
- No automated tests were present for this component so none were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c31ea11488323a31c359b4922cc70)